### PR TITLE
Add 19.0.0.10 release notes

### DIFF
--- a/releasenotes/master-docinfo.xml
+++ b/releasenotes/master-docinfo.xml
@@ -1,0 +1,16 @@
+<productname>Open Liberty</productname>
+<productnumber>19.0.0.10</productnumber>
+<subtitle>Release Notes for Open Liberty 19.0.0.10 on Red Hat OpenShift Container Platform</subtitle>
+<abstract>
+  <para>These release notes contain the latest information about new
+  features, enhancements, fixes, and issues contained in 
+  Open Liberty 19.0.0.10 on Red Hat OpenShift Container Platform release.</para>
+</abstract>
+<legalnotice lang="en-US" version="5.0" xmlns="http://docbook.org/ns/docbook">
+  <para>                Copyright <trademark class="copyright"></trademark> 2019 IBM Corp  </para>
+  <para>Code and build scripts are licensed under the Eclipse Public License v1
+Documentation files are licensed under Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
+
+  </para>
+
+</legalnotice>

--- a/releasenotes/master-remote.adoc
+++ b/releasenotes/master-remote.adoc
@@ -1,0 +1,19 @@
+:context: online
+
+= Release notes for Open Liberty 19.0.0.10 on Red Hat OpenShift Container Platform
+
+== Features
+
+include::https://raw.githubusercontent.com/OpenLiberty/blogs/master/publish/2019-10-11-configure-logs-JSON-format-190010.adoc[leveloffset=+1,lines=18..24;26..57,63..126]
+
+== Resolved issues
+
+See the https://github.com/OpenLiberty/open-liberty/issues?q=label%3A%22release+bug%22+label%3Arelease%3A190010+is%3Aclosed[Open Liberty 19.0.0.10 issues that were resolved for this release].
+
+== Fixed CVEs
+
+For a list of CVEs that were fixed in Open Liberty 19.0.0.10, see https://openliberty.io/docs/ref/general/#security-vulnerabilities.html[security vulnerabilities].
+
+== Known issues
+
+See the https://github.com/OpenLiberty/open-liberty/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22release+bug%22+created%3A2019-09-06..2019-10-04+-label%3Arelease%3A190010+[list of issues that were found but not fixed during the development of 19.0.0.10].


### PR DESCRIPTION
I've created the release notes for 19.0.0.10 using the template.

The features section is a remote include to the release blog post. I've used line numbers to capture the content so I don't have to redo the blog post. I'll work with Laura to see if we can use tagging in the blog post in future.

The list of fixed issues is a query into github issues for the release:190010 tag.

The CVE list is a link to the security vulnerabilities on openliberty.io.

The list of known issues is more complicated. I have created a query to github that looks for all release bugs found during 19.0.0.10 development, but not fixed in 19.0.0.10. When doing the next release the date range will need to be updated for the current release window.