### PR TITLE
Fix new features include

### DIFF
--- a/releasenotes/master-remote.adoc
+++ b/releasenotes/master-remote.adoc
@@ -4,7 +4,7 @@
 
 == Features
 
-include::https://raw.githubusercontent.com/OpenLiberty/blogs/master/publish/2019-10-11-configure-logs-JSON-format-190010.adoc[leveloffset=+1,lines=18..24;26..57,63..126]
+include::https://raw.githubusercontent.com/OpenLiberty/blogs/master/publish/2019-10-11-configure-logs-JSON-format-190010.adoc[leveloffset=+1,lines=18..24;26..57;63..126]
 
 == Resolved issues
 


### PR DESCRIPTION
The prior version of this used a , to separate two ranges, but this
only works if you use quotes. As a result the last range was interpreted
as a new processing instruction. Changing to a ; fixes it.