### PR TITLE
Added new include for release notes

### DIFF
--- a/releasenotes/master-remote.adoc
+++ b/releasenotes/master-remote.adoc
@@ -1,6 +1,6 @@
 :context: online
 
-= Release Notes for Open Liberty 19.0.0.10 on Red Hat OpenShift Container Platform
+= Release Notes for Open Liberty 19.0.0.12 on Red Hat OpenShift Container Platform
 
 == Features
 
@@ -8,12 +8,12 @@ include::https://raw.githubusercontent.com/OpenLiberty/blogs/master/publish/2019
 
 == Resolved issues
 
-See the https://github.com/OpenLiberty/open-liberty/issues?q=label%3A%22release+bug%22+label%3Arelease%3A190010+is%3Aclosed[Open Liberty 19.0.0.10 issues that were resolved for this release].
+See the https://github.com/OpenLiberty/open-liberty/issues?q=label%3A%22release+bug%22+label%3Arelease%3A190010+is%3Aclosed[Open Liberty 19.0.0.12 issues that were resolved for this release].
 
 == Fixed CVEs
 
-For a list of CVEs that were fixed in Open Liberty 19.0.0.10, see https://openliberty.io/docs/ref/general/#security-vulnerabilities.html[security vulnerabilities].
+For a list of CVEs that were fixed in Open Liberty 19.0.0.12, see https://openliberty.io/docs/ref/general/#security-vulnerabilities.html[security vulnerabilities].
 
 == Known issues
 
-See the https://github.com/OpenLiberty/open-liberty/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22release+bug%22+created%3A2019-09-06..2019-10-04+-label%3Arelease%3A190010+[list of issues that were found but not fixed during the development of 19.0.0.10].
+See the https://github.com/OpenLiberty/open-liberty/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22release+bug%22+created%3A2019-11-08..2019-12-06+-label%3Arelease%3A190012+[list of issues that were found but not fixed during the development of 19.0.0.12].

--- a/releasenotes/master-remote.adoc
+++ b/releasenotes/master-remote.adoc
@@ -4,7 +4,7 @@
 
 == Features
 
-include::https://raw.githubusercontent.com/OpenLiberty/blogs/master/publish/2019-10-11-configure-logs-JSON-format-190010.adoc[leveloffset=+1,lines=18..24;26..57;63..126]
+include::https://raw.githubusercontent.com/OpenLiberty/blogs/master/publish/2019-12-06-microprofile-32-health-metrics-190012.adoc[leveloffset=+1,tags=intro;run;features]
 
 == Resolved issues
 


### PR DESCRIPTION
We've tested the basic format of the tags parameter and that's fine. We've not been able to test the whole `include` statement, partly because the release blog post itself isn't yet available in that location (until it's published later today).

When the release blog post is published, you can find it at https://openliberty.io/blog/2019/12/06/microprofile-32-health-metrics-190012.html (at which point the include statement should work too).

So when it's built, it needs to be checked.