### PR TITLE
Update fetch-upstream.sh to grab necessary images

### DIFF
--- a/bin/fetch-upstream.sh
+++ b/bin/fetch-upstream.sh
@@ -1,3 +1,8 @@
 ./bin/asciidoc-coalescer.rb  -a allow-uri-read releasenotes/master-remote.adoc > releasenotes/master.adoc
 ./bin/asciidoc-coalescer.rb  -a allow-uri-read runtime-guide/master-remote.adoc > runtime-guide/master.adoc
 sed -i 's/:leveloffset!:/:leveloffset: -1/g' runtime-guide/master.adoc
+targets=$(cat releasenotes/master.adoc | grep 'image::' | cut -c8- | awk -F[ '{ print $1 }')
+for image in $targets; do
+    echo "Fetching image: '$image'"
+    curl https://raw.githubusercontent.com/OpenLiberty/blogs/prod/$image --create-dirs -o ../$image
+done


### PR DESCRIPTION
Adds to fetch-upstream.sh to have it download the necessary images from the main OpenLiberty repo. Images should always be in the correct location/branch on OpenLiberty/blogs before this script is run, so ideally there shouldn't be any issues.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>